### PR TITLE
feat: Add Wrangler configuration for Cloudflare Pages deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "budget-mini-app"
+compatibility_date = "2025-10-25"
+
+# Configuration for static assets (Vite build output)
+[site]
+bucket = "./dist"


### PR DESCRIPTION
Add wrangler.toml configuration file to specify the build output directory for Cloudflare Pages deployment. This resolves the deployment error where Wrangler couldn't locate the files to deploy.

Configuration:
- Set build output to ./dist directory (Vite default)
- Added compatibility date for Cloudflare Workers API

🤖 Generated with [Claude Code](https://claude.com/claude-code)