### PR TITLE
fix: Update Wrangler config to use modern assets syntax

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,5 +2,6 @@ name = "budget-mini-app"
 compatibility_date = "2025-10-25"
 
 # Configuration for static assets (Vite build output)
-[site]
-bucket = "./dist"
+# Using modern Wrangler 4.x syntax
+[assets]
+directory = "./dist"


### PR DESCRIPTION
Replace deprecated [site] configuration with [assets] for Wrangler 4.x compatibility. This resolves the "workers-site/index.js not found" error during deployment.

Changes:
- Replaced [site].bucket with [assets].directory
- Updated to Wrangler 4.x syntax for static asset deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)