### PR TITLE
fix: Remove unused imports in ApiTest component

### DIFF
--- a/src/components/ApiTest.tsx
+++ b/src/components/ApiTest.tsx
@@ -1,6 +1,4 @@
 import React, { useState } from 'react';
-import { fireflyAPI } from '../services/firefly';
-import { syncAPI } from '../services/sync';
 
 interface TestResult {
   name: string;


### PR DESCRIPTION
Removed unused fireflyAPI and syncAPI imports that were causing TypeScript compilation errors during build.

The component uses direct fetch calls instead of these service imports.

Fixes build error:
- TS2614: Module has no exported member
- TS6133: Variable is declared but its value is never read

🤖 Generated with [Claude Code](https://claude.com/claude-code)