### PR TITLE
fix: add proper top padding for Telegram Mini App

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Budget Mini App</title>
     <!-- Telegram WebApp SDK -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>

--- a/src/BudgetMiniApp.tsx
+++ b/src/BudgetMiniApp.tsx
@@ -315,7 +315,7 @@ const BudgetMiniApp = () => {
   };
 
   return (
-    <div className="max-w-md mx-auto bg-gray-900 min-h-screen">
+    <div className="max-w-md mx-auto bg-gray-900 min-h-screen pt-4">
       {/* Screen Router */}
       {currentScreen === 'home' && (
         <HomeScreen

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,7 @@
 body {
   margin: 0;
   padding: 0;
+  padding-top: env(safe-area-inset-top, 0);
   background: #111827;
 }
 


### PR DESCRIPTION
- Add viewport-fit=cover to viewport meta tag for iOS safe area support
- Add env(safe-area-inset-top) padding to body for adaptive top spacing
- Add pt-4 to main app container for consistent top margin across all screens

This fixes the issue where content was stuck to the top of the screen in Telegram Mini App, especially on iOS devices with notches.