### PR TITLE
fix: increase top padding from 16px to 32px for better spacing

### DIFF
--- a/src/BudgetMiniApp.tsx
+++ b/src/BudgetMiniApp.tsx
@@ -315,7 +315,7 @@ const BudgetMiniApp = () => {
   };
 
   return (
-    <div className="max-w-md mx-auto bg-gray-900 min-h-screen pt-4">
+    <div className="max-w-md mx-auto bg-gray-900 min-h-screen pt-8">
       {/* Screen Router */}
       {currentScreen === 'home' && (
         <HomeScreen


### PR DESCRIPTION
Changed pt-4 to pt-8 in main app container to provide more breathing room at the top of the Telegram Mini App interface.